### PR TITLE
Handle case where service no longer exists

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,26 @@ class virtualbox_windows(
       install_options => ['--allow-empty-checksums'],
     }
 
-    # Make sure the Virtualbox kernel driver is running
-    -> service { 'vboxdrv':
-      ensure => 'running',
-      enable => true,
+    case versioncmp($virtualbox_version, '6.1.30')
+    {
+      1:
+      {
+        # If the version of VB is greater than version 6.1.30 then 'vboxdrv' no longer exists on Windows.
+        $manage_vbox_drv = false
+      }
+      default:
+      {
+        # If the version of VB is less than or equal to 6.1.30 then 'vboxdrv' does exist and we should manage it.
+        $manage_vbox_drv = trues
+      }
+    }
+    if ($manage_vbox_drv == true)
+    {
+      # Make sure the Virtualbox kernel driver is running
+      service { 'vboxdrv':
+        ensure  => 'running',
+        enable  => true,
+        require => Package['virtualbox']
+      }
     }
 }


### PR DESCRIPTION
For versions of VirtualBox > `6.1.30` the `VBoxDrv` service no longer exists which means this module bombs out when using later versions of VB.
This PR makes managing that service dependant on the version installed. 